### PR TITLE
fix for when refs is undefined

### DIFF
--- a/src/vs/editor/contrib/referenceSearch/common/referenceSearch.ts
+++ b/src/vs/editor/contrib/referenceSearch/common/referenceSearch.ts
@@ -33,8 +33,10 @@ export function provideReferences(model: IReadOnlyModel, position: Position, pro
 	return TPromise.join(promises).then(references => {
 		const result: Location[] = [];
 		for (const refs of references) {
-			for (const ref of refs) {
-				result.push(ref);
+			if (refs) {
+				for (const ref of refs) {
+					result.push(ref);
+				}
 			}
 		}
 		return result;
@@ -69,8 +71,10 @@ export function provideWorkspaceReferences(modeId: string, workspace: URI, query
 	return TPromise.join(promises).then(references => {
 		const result: IReferenceInformation[] = [];
 		for (const refs of references) {
-			for (const ref of refs) {
-				result.push(ref);
+			if (refs) {
+				for (const ref of refs) {
+					result.push(ref);
+				}
 			}
 		}
 		return result;


### PR DESCRIPTION
@felixfbecker turns out this check that vscode had was necessary

It happens with us for go builtins. I may submit a patch upstream to clean this up, but for now I am just going to add back this check.

![screen shot 2017-03-01 at 10 30 12 am](https://cloud.githubusercontent.com/assets/754768/23474941/7b6fd318-fe6a-11e6-9070-9cc148c6c130.png)

Part of fix for https://github.com/sourcegraph/sourcegraph/issues/3712